### PR TITLE
fix permission issue in Actions workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -6,6 +6,9 @@ on:
     workflows: ["Update RELEASE on GitHub Release"]
     types:
       - completed
+      
+permissions:
+  id-token: write
 
 jobs:
   build-and-publish:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for publishing to PyPI. The most notable change is the addition of permissions for the `id-token` to enable secure authentication.

Workflow updates:

* [`.github/workflows/publish-to-pypi.yml`](diffhunk://#diff-75e8bbdd253f4a71a14114808840e63b6a9c23529499687d148025d860336504R10-R12): Added `permissions` with `id-token: write` to configure the workflow for secure authentication during the publishing process.

_(summary generated by GitHub Copilot)_